### PR TITLE
added templating for debug

### DIFF
--- a/tests/testthat/test-debug.R
+++ b/tests/testthat/test-debug.R
@@ -7,3 +7,13 @@ test_that("debug prints", {
     "pkg foobar"
   )
 })
+
+test_that("debug retrieves variables for placeholders", {
+  x <- "bar"
+  y <- 1
+
+  expect_output(
+    debug("x: {{x}}, y: {{y}}", pkg = "pkg"),
+    "x: bar, y: 1"
+  )
+})


### PR DESCRIPTION
I really like the idea of the package. I was just missing a way to include the value of variables in the output. Therefore I've patched `debug()` to retrieve variables for placeholders from the parent environment. 

It should now be possible to do stuff like this:
```{r}
path = file.path(tempdir())
ok = dir.create(file.path(path, "mydir"))
"!DEBUG Created directory {{path}}: {{ok}}"
"!DEBUG Files in {{path}}: {{length(list.files(path))}}"
```